### PR TITLE
Fix build error relating to yaml.safeLoad

### DIFF
--- a/scripts/default-data.js
+++ b/scripts/default-data.js
@@ -16,7 +16,7 @@ hexo.extend.helper.register('defaultData', (filename) => {
 
   try {
     let fileContents = fs.readFileSync(__dirname + `/../source/_default_data/${filename}.yaml`, 'utf8');
-		return yaml.safeLoad(fileContents);
+		return yaml.load(fileContents);
   } catch (e) {
     console.log(e);
     return null;


### PR DESCRIPTION
`Function yaml.safeLoad is removed in js-yaml 4. Use yaml.load instead, which is now safe by default.`